### PR TITLE
Added test for seeding input data defaults

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -36,6 +36,12 @@ describe('test the Seeding Input Form Data defaults', () => {
   })
 
   //Trang's Tests
+  it("Check if it has the header 'Data", () => {
+    cy.get("[data-cy=data_header]")
+      .should("have.text", "Data")
+
+  })
+
   it("", () => {
 
   })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -1,0 +1,5 @@
+//test the default contents of the "Data" section of the Seeding Input Form in the FieldKit
+//including header, date input element, and crop dropdown, 
+describe('test the Seeding Input Form Data defaults', () => {
+
+  })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -1,5 +1,34 @@
 //test the default contents of the "Data" section of the Seeding Input Form in the FieldKit
 //including header, date input element, and crop dropdown, 
 describe('test the Seeding Input Form Data defaults', () => {
+  beforeEach("Log into FarmData and visit FieldKit tab and Seeding Input sub-tab", () => {
+    cy.login('manager1', 'farmdata2')
+    cy.visit('/farm/fd2-field-kit/seedingInput')
+  })
+
+  //Ally's Tests
+  it("", () => {
+
+  })
+
+  //Charlie's Tests
+  it("Checks if crop drop down is correct", () => {
+    //Checks if the drop down has a selected value; it should not
+    cy.get("[data-cy=crop-selection]")
+      .should("have.value","")
+
+    //Checks to see if the drop down contains the correct crop list by checking the length and if certain indexes have the correct values
+    cy.get("[data-cy=crop-selection] > [data-cy=dropdown-input]").children()
+      .should("have.length","111")
+    cy.get("[data-cy=crop-selection] > [data-cy=dropdown-input] > [data-cy=option0]")
+      .should("have.text","ARUGULA")
+    cy.get("[data-cy=crop-selection] > [data-cy=dropdown-input] > [data-cy=option110]")
+      .should("have.text","ZUCCHINI")
+  })
+
+  //Trang's Tests
+  it("", () => {
+
+  })
 
   })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -7,9 +7,17 @@ describe('test the Seeding Input Form Data defaults', () => {
   })
 
   //Ally's Tests
-  it("", () => {
+  it("Check default value of date input element", () => {
+    cy.get("[data-cy=date-selection] > [data-cy=date-select]")
+      .should("have.value","2023-11-01")
+  })
+
+  it("Check that crop drop down is enabled", () => {
+    cy.get("[data-cy=crop-selection]")
+      .should("exist")
 
   })
+
 
   //Charlie's Tests
   it("Checks if crop drop down is correct", () => {

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -6,22 +6,24 @@ describe('test the Seeding Input Form Data defaults', () => {
     cy.visit('/farm/fd2-field-kit/seedingInput')
   })
 
-  //Ally's Tests
+
   it("Check default value of date input element", () => {
+    //check that date input element is enabled
+    cy.get("[data-cy=date-selection]")
+      .should("exist")
+
+    //check that default value is correct
     const dayjs = require('dayjs')
     cy.get("[data-cy=date-selection] > [data-cy=date-select]")
       .should("have.value",dayjs().format('YYYY-MM-DD').toString())
   })
 
-  it("Check that crop drop down is enabled", () => {
-    cy.get("[data-cy=crop-selection]")
-      .should("exist")
 
-  })
-
-
-  //Charlie's Tests
   it("Checks if crop drop down is correct", () => {
+    //check that drop down is enabled
+    cy.get("[data-cy=crop-selection]")
+    .should("exist")
+
     //Checks if the drop down has a selected value; it should not
     cy.get("[data-cy=crop-selection]")
       .should("have.value","")
@@ -35,17 +37,11 @@ describe('test the Seeding Input Form Data defaults', () => {
       .should("have.text","ZUCCHINI")
   })
 
-  //Trang's Tests
   it("Check if it has the header 'Data", () => {
     cy.get("[data-cy=data_header]")
       .should("have.text", "Data")
 
   })
 
-  it("Check date input element is enabled", () => {
-    cy.get("data-cy=date-selection")
-    .should("exist")
-    
-  })
 
   })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -8,8 +8,9 @@ describe('test the Seeding Input Form Data defaults', () => {
 
   //Ally's Tests
   it("Check default value of date input element", () => {
+    const dayjs = require('dayjs')
     cy.get("[data-cy=date-selection] > [data-cy=date-select]")
-      .should("have.value","2023-11-01")
+      .should("have.value",dayjs().format('YYYY-MM-DD').toString())
   })
 
   it("Check that crop drop down is enabled", () => {

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.data.defaults.spec.js
@@ -42,8 +42,10 @@ describe('test the Seeding Input Form Data defaults', () => {
 
   })
 
-  it("", () => {
-
+  it("Check date input element is enabled", () => {
+    cy.get("data-cy=date-selection")
+    .should("exist")
+    
   })
 
   })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -12,7 +12,7 @@
         </div>
         <br>
         <fieldset class="panel panel-default center-block" style='max-width: 500px;'>
-            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Data</legend>
+            <legend data-cy="data_header" class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Data</legend>
             <div class="center-block" style='padding: 12px; text-align:center; font-size: medium; margin-top: 45px'>
                 <date-selection data-cy="date-selection" :set-date='selectedDate' @date-changed='setNewDate' :disabled='submitInProgress'>Date:<label style='color: #da4f3f'>*</label></date-selection> 
                 <br>


### PR DESCRIPTION
__Pull Request Description__

Adds a file to test the default content in the seeding input data, including the header, date input element, and crop dropdown.

Addresses #12

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
