### PR TITLE
Test seeding input type defaults 13

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
@@ -9,4 +9,9 @@ describe("Ensure Seeding Input Log has sane default values", () => {
     it("Direct seeding is enabled", () => {
         cy.get("[data-cy='direct-seedings']").should('be.enabled')
     })
+    it("Tray and Direct elements not selected and message visible", () => {
+        cy.get("[data-cy='tray-seedings']").should('not.be.checked')
+        cy.get("[data-cy='direct-seedings']").should('not.be.checked')
+        cy.contains("Please Select Tray Seeding or Direct Seeding")
+    })
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
@@ -1,17 +1,38 @@
-describe("Ensure Seeding Input Log has sane default values", () => {
+describe("Ensure Seeding Input Log has same default values", () => {
     beforeEach(() => {
         cy.login("manager1", "farmdata2")
         cy.visit("/farm/fd2-field-kit/seedingInput")
     })
+
+    /** Check elements for "Tray" and "Direct" are enabled. */
     it("Tray seeding is enabled", () => {
         cy.get("[data-cy='tray-seedings']").should('be.enabled')
     })
     it("Direct seeding is enabled", () => {
         cy.get("[data-cy='direct-seedings']").should('be.enabled')
     })
+
+    /** Check neither Tray nor Direct is selected and
+     *  a message is visible indicating that Tray or Direct must be selected. */
     it("Tray and Direct elements not selected and message visible", () => {
         cy.get("[data-cy='tray-seedings']").should('not.be.checked')
         cy.get("[data-cy='direct-seedings']").should('not.be.checked')
         cy.contains("Please Select Tray Seeding or Direct Seeding")
     })
+
+    /** Check the form elements for either the "Tray" and 
+    "Direct" seedings are not visible or do not exist. */
+
+    it("Check form elements of Tray is not visible or not exist", () => { 
+        cy.get("[data-cy=tray-area-selection]").should("not.be.visible")
+        cy.get("[data-cy=num-cell-input]").should("not.be.visible")
+        cy.get("[data-cy=num-tray-input]").should("not.be.visible")
+        cy.get("[data-cy=num-seed-input]").should("not.be.visible")
+    }) 
+    it("Check form elements of Direct is not visible or not exist", () => { 
+        cy.get("[data-cy=direct-area-selection]").should("not.be.visible")
+        cy.get("[data-cy=num-rowbed-input]").should("not.be.visible")
+        cy.get("[data-cy=unit-feet]").should("not.be.visible")
+        cy.get("[data-cy=num-feet-input]").should("not.be.visible")
+    }) 
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
@@ -1,0 +1,12 @@
+describe("Ensure Seeding Input Log has sane default values", () => {
+    beforeEach(() => {
+        cy.login("manager1", "farmdata2")
+        cy.visit("/farm/fd2-field-kit/seedingInput")
+    })
+    it("Tray seeding is enabled", () => {
+        cy.get("[data-cy='tray-seedings']").should('be.enabled')
+    })
+    it("Direct seeding is enabled", () => {
+        cy.get("[data-cy='direct-seedings']").should('be.enabled')
+    })
+})


### PR DESCRIPTION
__Pull Request Description__

The tests created for this issue will test the default contents of the "Seeding Type" (Tray/Direct) section of the Seeding Input Form in the FieldKit.

Closed #13 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
