### PR TITLE
Added tests for Seeding Input Labor Defaults

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -53,7 +53,7 @@
             </div>
         </fieldset>   
         <fieldset class="panel panel-default center-block" style="max-width: 500px;" v-show="configToIDMap.labor != 'Hidden'">
-            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Labor</legend>
+            <legend data-cy="labor_header" class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Labor</legend>
             <div class="center-block" style='padding: 12px;text-align:center;font-size: medium; margin-top: 45px;'>
                 <label style='color: #da4f3f' v-show="configToIDMap.labor == 'Required'">*&nbsp;</label>
                 <regex-input data-cy='num-worker-input' :reg-exp="regNumWorker" :default-val="numWorkers" set-type="number" set-min="0" :disabled="submitInProgress" @input-changed="setNewNumWorkers" @match-changed="(newBool) => updateValidMap('validNumWorkers', newBool)"></regex-input>                                                

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -1,0 +1,16 @@
+describe('Test the seeding input page', () => {
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+        cy.visit('/farm/fd2-field-kit/seedingInput')
+    }) 
+
+    it("Testing time units dropdown", () => {
+        //Checks the time units dropdown has the options minutes and hours
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option0]")
+           .should("have.text", "minutes")
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option1]")
+            .should("have.text", "hours")
+
+    })
+
+})

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -10,6 +10,10 @@ describe('Test the seeding input page', () => {
            .should("have.text", "minutes")
         cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option1]")
             .should("have.text", "hours")
+        
+        //Checks minutes is the default time units for labor data entry
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] option:selected")
+        .should("have.text", "minutes")
 
     })
 

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -4,6 +4,11 @@ describe('Test the seeding input page', () => {
         cy.visit('/farm/fd2-field-kit/seedingInput')
     }) 
 
+    it("Testing the header", () => {
+        cy.get("[data-cy=labor_header]")
+        .should("have.text", "Labor")
+    })
+
     it("Testing time units dropdown", () => {
         //Checks the time units dropdown has the options minutes and hours
         cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option0]")

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -22,4 +22,20 @@ describe('Test the seeding input page', () => {
 
     })
 
+    it("Test the number of workers field", () => {
+        //Check the field of number of workers should be empty and enabled
+        cy.get("[data-cy=num-worker-input]").should('exist').should("have.value", "")
+    })
+
+    it("Test the time worked field", () => {
+        //Check the field of number of time worked should be empty and enabled
+        cy.get("[data-cy=minute-input]").should('exist').should("have.value", "")
+        cy.get("[data-cy=hour-input]").should('exist').should("have.value", "")
+    })
+
+    it("Test the time unit dropdown", () => {
+        //Check the dropdown for the time units is enabled
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] option:selected").should('exist')
+    })
+
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -22,6 +22,7 @@ describe('Test the seeding input page', () => {
 
     })
 
+    //Monica's Test
     it("Test the number of workers field", () => {
         //Check the field of number of workers should be empty and enabled
         cy.get("[data-cy=num-worker-input]").should('exist').should("have.value", "")


### PR DESCRIPTION
__Pull Request Description__
Closes #14 
Added file to test the Labor section of the Seeding Input Form, including header, unit dropdown options, and fields for the number of workers and time worked

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
