### PR TITLE
Added Tests for Seeding Report: Seeding Type Filter

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -899,11 +899,9 @@
                         this.errBannerVisibility = true
                     })
 
-                // Need better way to detect if running on mobile to adjust visible table columns.
-                // Removing this makes isMobile always false, so all columns appear all the time for now.
-                //if (window.screen.width < 900 || window.screen.height < 900) {
-                //    this.isMobile = true
-                //}
+                if (window.screen.width < 900 || window.screen.height < 900) {
+                    this.isMobile = true
+                }
             }
         })
         Vue.config.devtools = true;

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -207,7 +207,7 @@
                     let updatePlantObject = {}
                     
                     /**
-                     * The Table component returns an object with the cells that were updated. We don't know how many or wich ones where updated, so we check for all possible cells that could have been updated.
+                     * The Table component returns an object with the cells that were updated. We don't know how many or which ones where updated, so we check for all possible cells that could have been updated.
                      */
                     let keys = Object.keys(updateObject)
 

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
@@ -11,17 +11,61 @@ describe('Test the seeding input page', () => {
         cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
         cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-02-15')
         cy.get('[data-cy=generate-rpt-btn]')
                 .click()
 
-        //select All for the type of seeding
-        cy.get("[data-cy=seeding-type-dropdown]>[data-cy=dropdown-input]").select("All")
-
         //check if table has both direct and tray seedings
+        let typeSeeding = null
+        cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+            .select('All')
+            .should('have.value', 'All')
+
+        for(let r = 0; r < 6; r++){
+            cy.get('[data-cy=r' + r + '-Seeding')
+                .invoke('text')
+                .then(seeding => {
+                    typeSeeding = seeding
+                    expect(typeSeeding, 'Direct')
+                })
+        }
+
+        for(let r = 6; r < 9; r++){
+            cy.get('[data-cy=r' + r + '-Seeding')
+                .invoke('text')
+                .then(seeding => {
+                    typeSeeding = seeding
+                    expect(typeSeeding, 'Tray')
+                })
+        }
+
     })
 
     //when “Direct” is selected the table shows only direct seedings.
+    it("Check table showing only direct seedings", () => {
+        //Choose a specific date range
+        cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+        cy.get('[data-cy=end-date-select]')
+                .type('2019-02-15')
+        cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+
+        //check if table has only direct seedings
+        let typeSeeding = null
+        cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+            .select('Direct Seedings')
+            .should('have.value', 'Direct Seedings')
+
+        for(let r = 0; r < 6; r++){
+            cy.get('[data-cy=r' + r + '-Seeding')
+                .invoke('text')
+                .then(seeding => {
+                    typeSeeding = seeding
+                    expect(typeSeeding, 'Direct')
+                })
+        }
+    })
 
 
     //when "Tray" is selected the table shows only tray seedings. 

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
@@ -16,7 +16,7 @@ describe('Test the seeding input page', () => {
                 .click()
 
         //select All for the type of seeding
-        cy.get("[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]").select("All")
+        cy.get("[data-cy=seeding-type-dropdown]>[data-cy=dropdown-input]").select("All")
 
         //check if table has both direct and tray seedings
     })
@@ -26,33 +26,22 @@ describe('Test the seeding input page', () => {
 
     //when "Tray" is selected the table shows only tray seedings. 
     it("Check table showing only tray seedings", () => {
-                //Choose a specific date range
-                cy.get('[data-cy=start-date-select]')
+        //Choose a specific date range
+        cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
         cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-02-15')
         cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]').select("Tray Seedings")
 
-        cy.get('[data-cy=r1-Area]')
-        .should("have.text", "SEEDING BENCH")
+        let rows = ["0", "1", "2"]
+        for (let i=0; i < rows.length; i++){
+                cy.get('[data-cy=r'+ rows[i] +'-Area]')
+                .should("have.text", "SEEDING BENCH")
+        }
     })
 
-        //when "Tray" is selected the table shows only tray seedings. 
-        it("Check table showing only tray seedings", () => {
-                //Choose a specific date range
-                cy.get('[data-cy=start-date-select]')
-                .type('2019-01-01')
-        cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
-        cy.get('[data-cy=generate-rpt-btn]')
-                .click()
-        cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]').select("Tray Seedings")
-
-        cy.get('[data-cy=r1-Area]')
-        .should("have.text", "SEEDING BENCH")
-    })
 
         //Only the seeding types available in the date range are shown in the dropdown 
         it("Check available seeding types are shown in dropdown in date range", () => {

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
@@ -40,7 +40,7 @@ describe('Test the seeding input page', () => {
         }
 
     })
-
+    /*
     //when “Direct” is selected the table shows only direct seedings.
     it("Check table showing only direct seedings", () => {
         //Choose a specific date range
@@ -66,6 +66,23 @@ describe('Test the seeding input page', () => {
                 })
         }
     })
+    */
+        //when "Direct" is selected the table shows only tray seedings. 
+        it("Check table showing only direct seedings", () => {
+                //Choose a specific date range
+                cy.get('[data-cy=start-date-select]')
+                        .type('2019-01-01')
+                cy.get('[data-cy=end-date-select]')
+                        .type('2019-03-20')
+                cy.get('[data-cy=generate-rpt-btn]')
+                        .click()
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]').select("Direct Seedings")
+
+                for (let i=0; i < 7; i++){
+                        cy.get('[data-cy=r'+ i +'-Area]')
+                        .should("not.have.text", "SEEDING BENCH")
+                }
+                })
 
 
     //when "Tray" is selected the table shows only tray seedings. 
@@ -74,14 +91,14 @@ describe('Test the seeding input page', () => {
         cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
         cy.get('[data-cy=end-date-select]')
-                .type('2019-02-15')
+                .type('2019-03-01')
         cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]').select("Tray Seedings")
 
         let rows = ["0", "1", "2"]
-        for (let i=0; i < rows.length; i++){
-                cy.get('[data-cy=r'+ rows[i] +'-Area]')
+        for (let i=0; i < 27; i++){
+                cy.get('[data-cy=r'+ i +'-Area]')
                 .should("have.text", "SEEDING BENCH")
         }
     })

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
@@ -1,0 +1,6 @@
+describe('Test the seeding input page', () => {
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+        cy.visit('/farm/fd2-field-kit/seedingInput')
+    }) 
+})

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
@@ -1,6 +1,24 @@
 describe('Test the seeding input page', () => {
     beforeEach(() => {
         cy.login('manager1', 'farmdata2')
-        cy.visit('/farm/fd2-field-kit/seedingInput')
+        cy.visit('/farm/fd2-barn-kit/seedingReport')
     }) 
+
+    //“All” is selected the table shows both direct seedings and tray seedings
+    it("Check table showing both direct and tray seedings", () => {
+        //Choose a specific date range
+        cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+        cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+        cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+
+        //select All for the type of seeding
+        cy.get("[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]").select("All")
+
+        //check if table has both direct and tray seedings
+    })
+
+    //when “Direct” is selected the table shows only direct seedings.
 })

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.typeFilter.spec.js
@@ -2,6 +2,7 @@ describe('Test the seeding input page', () => {
     beforeEach(() => {
         cy.login('manager1', 'farmdata2')
         cy.visit('/farm/fd2-barn-kit/seedingReport')
+        cy.waitForPage()
     }) 
 
     //“All” is selected the table shows both direct seedings and tray seedings
@@ -21,4 +22,93 @@ describe('Test the seeding input page', () => {
     })
 
     //when “Direct” is selected the table shows only direct seedings.
+
+
+    //when "Tray" is selected the table shows only tray seedings. 
+    it("Check table showing only tray seedings", () => {
+                //Choose a specific date range
+                cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+        cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+        cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]').select("Tray Seedings")
+
+        cy.get('[data-cy=r1-Area]')
+        .should("have.text", "SEEDING BENCH")
+    })
+
+        //when "Tray" is selected the table shows only tray seedings. 
+        it("Check table showing only tray seedings", () => {
+                //Choose a specific date range
+                cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+        cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+        cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]').select("Tray Seedings")
+
+        cy.get('[data-cy=r1-Area]')
+        .should("have.text", "SEEDING BENCH")
+    })
+
+        //Only the seeding types available in the date range are shown in the dropdown 
+        it("Check available seeding types are shown in dropdown in date range", () => {
+
+                //Choose a specific date range (Only All & Direct are available)
+                cy.get('[data-cy=start-date-select]')
+                        .type('2019-01-01')
+                cy.get('[data-cy=end-date-select]')
+                        .type('2019-02-01')
+                cy.get('[data-cy=generate-rpt-btn]')
+                        .click()
+                //Counts the number of options available
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                .should("have.length", 2)
+                //Checks the options are All and Direct
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input] [data-cy=option0]')
+                        .should("have.text", "All")
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input] [data-cy=option1]')
+                .should("have.text", "Direct Seedings")
+
+
+                //Choose a specific date range (Only All & Tray are available)
+                cy.get('[data-cy=end-date-select]')
+                        .type('2019-03-04')
+                cy.get('[data-cy=start-date-select]')
+                        .type('2019-03-01')
+
+                cy.get('[data-cy=generate-rpt-btn]')
+                        .click()
+                //Counts the number of options available
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                .should("have.length", 2)
+                //Checks the options are All and Direct
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input] [data-cy=option0]')
+                        .should("have.text", "All")
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input] [data-cy=option1]')
+                .should("have.text", "Tray Seedings")
+
+
+                //Choose a specific date range (Every options are available)
+                cy.get('[data-cy=start-date-select]')
+                .type('2019-01-11')
+                cy.get('[data-cy=end-date-select]')
+                .type('2019-02-16')
+                cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+                //Counts the number of options available
+                cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                .should("have.length", 3)
+
+
+
+    })
+
+
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -53,7 +53,7 @@
             </div>
         </fieldset>   
         <fieldset class="panel panel-default center-block" style="max-width: 500px;" v-show="configToIDMap.labor != 'Hidden'">
-            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Labor</legend>
+            <legend data-cy="labor_header" class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Labor</legend>
             <div class="center-block" style='padding: 12px;text-align:center;font-size: medium; margin-top: 45px;'>
                 <label style='color: #da4f3f' v-show="configToIDMap.labor == 'Required'">*&nbsp;</label>
                 <regex-input data-cy='num-worker-input' :reg-exp="regNumWorker" :default-val="numWorkers" set-type="number" set-min="0" :disabled="submitInProgress" @input-changed="setNewNumWorkers" @match-changed="(newBool) => updateValidMap('validNumWorkers', newBool)"></regex-input>                                                

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -1,0 +1,16 @@
+describe('Test the seeding input page', () => {
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+        cy.visit('/farm/fd2-field-kit/seedingInput')
+    }) 
+
+    it("Testing time units dropdown", () => {
+        //Checks the time units dropdown has the options minutes and hours
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option0]")
+           .should("have.text", "minutes")
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option1]")
+            .should("have.text", "hours")
+
+    })
+
+})

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -10,6 +10,10 @@ describe('Test the seeding input page', () => {
            .should("have.text", "minutes")
         cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option1]")
             .should("have.text", "hours")
+        
+        //Checks minutes is the default time units for labor data entry
+        cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] option:selected")
+        .should("have.text", "minutes")
 
     })
 

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -4,6 +4,11 @@ describe('Test the seeding input page', () => {
         cy.visit('/farm/fd2-field-kit/seedingInput')
     }) 
 
+    it("Testing the header", () => {
+        cy.get("[data-cy=labor_header]")
+        .should("have.text", "Labor")
+    })
+
     it("Testing time units dropdown", () => {
         //Checks the time units dropdown has the options minutes and hours
         cy.get("[data-cy=time-unit] > [data-cy=dropdown-input] > [data-cy=option0]")


### PR DESCRIPTION
__Pull Request Description__

Closes #19 
Added tests to ensure that generated seeding reports only contain the selected seeding type and that only seeding types available within the date range are shown in the dropdown. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
